### PR TITLE
Fix mobile persona menu hidden behind search dialog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ REACT_APP_AITO_API_KEY=yg4rTlXkqDzm4y8gPeY75HCKaNwfbTQ2si64ONTi
 REACT_APP_ENVIRONMENT=development
 
 # Port Configuration
+PORT=3100
 # Backend server port (defaults to 3010 if not specified)
 BACKEND_PORT=3010
 

--- a/src/app/components/NavBar.css
+++ b/src/app/components/NavBar.css
@@ -239,6 +239,8 @@
   padding: var(--aito-spacing-sm) var(--aito-spacing-md);
   background-color: var(--aito-background);
   border-bottom: 1px solid var(--aito-border);
+  position: relative;
+  z-index: 1050;
 }
 
 @media (min-width: 769px) {


### PR DESCRIPTION
## Summary
- Fix persona dropdown menu (Larry, Alice, etc.) being hidden behind the search container on mobile by adding `position: relative; z-index: 1050` to `.NavBar__mobile`
- Set default dev server port to 3100

## Test plan
- [ ] Open the app on a mobile viewport (< 769px)
- [ ] Click the persona icon in the top bar to open the dropdown
- [ ] Verify the dropdown (Larry, Veronica, Alice, Unknown user) renders above the search bar
- [ ] Verify the mobile drawer menu still works correctly (z-index 1100 > 1050)

🤖 Generated with [Claude Code](https://claude.com/claude-code)