### PR TITLE
Latency pill: visible Aito call timings on every interaction

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -10,6 +10,7 @@ import * as data from './data'
 import { initAnalytics, trackPage, trackEvent, identifyUser } from '../analytics'
 import NavBar from './components/NavBar'
 import ContextPanel from './components/ContextPanel'
+import LatencyPill from './components/LatencyPill'
 import LandingPage from './pages/LandingPage'
 import AdminPage from './pages/AdminPage'
 import AnalyticsPage from './pages/AnalyticsPage'
@@ -347,6 +348,11 @@ class App extends Component {
         </div>
 
         <ContextPanel urlPath={state.urlPath} />
+
+        {/* Corner badge showing the most-recent Aito call's endpoint +
+            wall time. Listens for `aito:calls` window events emitted by
+            the axios interceptor (src/services/aitoTiming.js). */}
+        <LatencyPill />
 
         <Modal color="danger" isOpen={modalOpen} toggle={() => this.showError(null)}>
           <ModalHeader toggle={() => this.showError(null)}>Error</ModalHeader>

--- a/src/app/components/LatencyPill.css
+++ b/src/app/components/LatencyPill.css
@@ -1,0 +1,62 @@
+/* Per-call Aito latency badge — fixed bottom-right corner, fades in
+   on every API response, auto-hides after 4 s. */
+.LatencyPill {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 1200;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background-color: rgba(12, 15, 65, 0.94);
+  color: #fff;
+  border-radius: 18px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  box-shadow: 0 4px 14px rgba(12, 15, 65, 0.18);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  pointer-events: none;
+}
+.LatencyPill--visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+.LatencyPill__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #12B5AD;
+  box-shadow: 0 0 6px rgba(18, 181, 173, 0.6);
+}
+.LatencyPill__endpoint {
+  color: #12B5AD;
+  font-weight: 500;
+}
+.LatencyPill__ms {
+  color: rgba(255, 255, 255, 0.92);
+  font-weight: 600;
+}
+
+/* Error states — red accent so timeouts/4xx/5xx don't masquerade as
+   sub-50ms wins. */
+.LatencyPill--error .LatencyPill__dot {
+  background: #ff6b6b;
+  box-shadow: 0 0 6px rgba(255, 107, 107, 0.6);
+}
+.LatencyPill--error .LatencyPill__endpoint {
+  color: #ff6b6b;
+}
+
+/* Mobile: lift above the ContextPanel info button (bottom: 24px)
+   so they don't stack on the same pixel. */
+@media (max-width: 768px) {
+  .LatencyPill {
+    bottom: 80px;
+    right: 16px;
+  }
+}

--- a/src/app/components/LatencyPill.js
+++ b/src/app/components/LatencyPill.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react'
+import { AITO_CALLS_EVENT } from '../../services/aitoTiming'
+import './LatencyPill.css'
+
+/**
+ * Corner badge showing the most-recent Aito call's endpoint + wall time.
+ *
+ * Visceral proof of the latency claims on aito.ai/solutions: visitors
+ * watch `_predict 28ms` / `_recommend 142ms` flash as they click
+ * around. Auto-fades after 4 s of idle so it doesn't compete with the
+ * primary content; re-armed on every new event.
+ *
+ * Same pattern shipped on the ERP demo
+ * (aito-erp-demo/frontend/components/shell/LatencyPill.tsx). Different
+ * runtime — axios interceptor here, fetch wrapper there — but the
+ * window-event interface is identical.
+ */
+export default function LatencyPill() {
+  const [event, setEvent] = useState(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    let timeoutId
+    const handler = (e) => {
+      setEvent(e.detail)
+      setVisible(true)
+      if (timeoutId) window.clearTimeout(timeoutId)
+      timeoutId = window.setTimeout(() => setVisible(false), 4000)
+    }
+    window.addEventListener(AITO_CALLS_EVENT, handler)
+    return () => {
+      window.removeEventListener(AITO_CALLS_EVENT, handler)
+      if (timeoutId) window.clearTimeout(timeoutId)
+    }
+  }, [])
+
+  if (!event) return null
+
+  const ms = Math.round(event.ms)
+  const isError = event.status >= 400 || event.status === 0
+
+  return (
+    <div
+      className={`LatencyPill${visible ? ' LatencyPill--visible' : ''}${isError ? ' LatencyPill--error' : ''}`}
+      title={`${event.endpoint} returned in ${ms} ms` + (isError ? ` (status ${event.status})` : '')}
+    >
+      <span className="LatencyPill__dot" />
+      <span className="LatencyPill__endpoint">{event.endpoint}</span>
+      <span className="LatencyPill__ms">{ms}ms</span>
+    </div>
+  )
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './app/App'
+import { installAitoTiming } from './services/aitoTiming'
 
 import './app/styles/bootstrap.min.css'
 import './app/index.css'
+
+// Hook the global axios interceptor before any component mounts —
+// powers the corner LatencyPill that shows `_predict 28ms` and
+// friends as visitors click around. See src/services/aitoTiming.js.
+installAitoTiming()
 
 ReactDOM.render(<App />, document.getElementById('root'))
 

--- a/src/services/aitoTiming.js
+++ b/src/services/aitoTiming.js
@@ -1,0 +1,66 @@
+/**
+ * Per-call Aito timing — global axios interceptor + window event bus.
+ *
+ * Visitors see a corner badge showing `_predict 28ms · _relate 142ms`
+ * as queries fly. Same pattern shipped on aito-erp-demo
+ * (frontend/components/shell/LatencyPill.tsx); applied here without
+ * touching the dozens of `axios.post(`${config.aito.url}/...`)` call
+ * sites by hooking the global axios request/response interceptors.
+ *
+ * The pill subscribes to `window` events of type AITO_CALLS_EVENT.
+ * Each event carries one Aito call's endpoint name (e.g. "_predict")
+ * and wall-time duration in ms.
+ */
+
+import axios from 'axios'
+
+export const AITO_CALLS_EVENT = 'aito:calls'
+
+/** Pull the bare endpoint name out of a request URL.
+ *  e.g. "https://x.aito.app/api/v1/_predict" → "_predict". Anything
+ *  outside the Aito API surface returns null so we don't fire events
+ *  for OpenAI / analytics / etc. calls. */
+function endpointFromUrl(url) {
+  if (!url || typeof url !== 'string') return null
+  const m = url.match(/\/api\/v1\/(_[a-z]+)/i)
+  return m ? m[1] : null
+}
+
+let installed = false
+
+/** Idempotent — calling install twice doesn't double-instrument
+ *  (multiple module imports during dev hot-reload are common). */
+export function installAitoTiming() {
+  if (installed) return
+  installed = true
+
+  axios.interceptors.request.use((config) => {
+    config.metadata = config.metadata || {}
+    config.metadata.aitoStart = performance.now()
+    return config
+  }, (error) => Promise.reject(error))
+
+  const broadcast = (config, status) => {
+    const endpoint = endpointFromUrl(config?.url)
+    if (!endpoint) return
+    const start = config?.metadata?.aitoStart
+    if (typeof start !== 'number') return
+    const ms = performance.now() - start
+    if (typeof window === 'undefined') return
+    window.dispatchEvent(new CustomEvent(AITO_CALLS_EVENT, {
+      detail: { endpoint, ms, status },
+    }))
+  }
+
+  axios.interceptors.response.use(
+    (response) => {
+      broadcast(response.config, response.status)
+      return response
+    },
+    (error) => {
+      // Surface failures too — a slow failing call is still informative.
+      broadcast(error.config, error.response?.status ?? 0)
+      return Promise.reject(error)
+    },
+  )
+}


### PR DESCRIPTION
## Summary
- Persistent corner badge showing `_predict 28ms` / `_recommend 91ms` / `_relate 142ms` as Aito queries fly. Visceral proof of the latency claims on aito.ai/solutions — visitors see real call timings without opening dev tools.
- Implemented as a global axios interceptor + a `LatencyPill` React component subscribed to `aito:calls` window events.
- Same UX shipped on [aito-erp-demo](https://github.com/AitoDotAI/aito-erp-demo) in commit [094e1aa](https://github.com/AitoDotAI/aito-erp-demo/commit/094e1aa). The window-event interface is identical; only the runtime hook differs (axios interceptor here vs. fetch wrapper in the ERP demo).

## How it works
- `src/services/aitoTiming.js` installs the interceptor on app boot from `src/index.js`. Stamps `config.metadata.aitoStart` on request, computes wall time on response, parses the endpoint name from the URL (`/api/v1/_predict` → `_predict`), and dispatches a window event. Non-Aito axios calls (OpenAI, analytics) are filtered out by the URL match — the regex only fires on `/api/v1/_<op>` paths.
- `src/app/components/LatencyPill.{js,css}` renders the badge bottom-right, auto-fades after 4 s, re-arms on every new event. Error responses (4xx/5xx or network failures) get a red dot so a slow timeout doesn't masquerade as a sub-50ms win.
- Mounted in `App.js` next to `<ContextPanel />`.
- Mobile: pill lifts to `bottom: 80px` so it doesn't stack on the ContextPanel info button at `bottom: 24px`.

## Test plan
- [ ] `npm start` and click around the customer experience — pill should flash on every interaction (search, autocomplete, recommendations).
- [ ] Open product detail page — `_predict` calls visible.
- [ ] Open invoicing page — `_predict` calls visible.
- [ ] Throttle network to 3G in DevTools — pill should show realistic ~200-500ms timings.
- [ ] Stop the Aito instance / break the URL — error responses should show with the red dot.
- [ ] Mobile viewport (≤ 768px) — pill should sit above the floating ContextPanel button, not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)