### PR TITLE
Fix product analytics relate query and stack LatencyPill above chat button

### DIFF
--- a/src/09-product.js
+++ b/src/09-product.js
@@ -75,15 +75,23 @@ export function getProductStats(id){
  */
 export function getProductAnalytics(id){
 
-  // Execute multiple analytics queries in parallel using batch API
-  return axios.post(`${config.aito.url}/api/v1/_batch`,
+  // First fetch the product so we can pass its full set of properties
+  // as the relate proposition. Passing the object lets Aito enumerate
+  // propositions on each property of THIS product (name, category, tags,
+  // cost, price, googleClicks, ...) without the duplicate-condition issue
+  // we got from `relate: {product: id}` after the proposition-selection
+  // change.
+  return getProductDetails(id).then(productResp => {
+    const product = (productResp.hits && productResp.hits[0]) || {}
+    const { id: _ignored, ...productProps } = product
+
+    return axios.post(`${config.aito.url}/api/v1/_batch`,
     [
-      { // Analyze which product properties correlate with purchases
+      { // Which of this product's properties are over-represented in
+        // purchases vs the baseline of all impressions?
         "from": "impressions",
         "where": {"purchase": true},
-        "relate": {
-          "product": id
-        },
+        "relate": {"product": productProps},
         "select": ["lift", "related"]
       },
       { // Analyze correlation between user demographics and this product
@@ -125,9 +133,8 @@ export function getProductAnalytics(id){
         ]
       }
     ], {
-    headers: { 'x-api-key': config.aito.apiKey },
-  })
-    .then(response => {
-      return response.data    
+      headers: { 'x-api-key': config.aito.apiKey },
+    })
+      .then(response => response.data)
   })
 }

--- a/src/app/components/ChatWidget.js
+++ b/src/app/components/ChatWidget.js
@@ -27,12 +27,20 @@ class ChatWidget extends Component {
   }
 
   componentDidMount() {
+    // Mark the body so other fixed-position widgets (LatencyPill) can
+    // lift themselves above the chat button on pages that show it.
+    document.body.classList.add('has-chat-widget');
+
     // Show initial unread indicator after a delay
     setTimeout(() => {
       if (!this.state.isOpen) {
         this.setState({ unreadCount: 1 });
       }
     }, 3000);
+  }
+
+  componentWillUnmount() {
+    document.body.classList.remove('has-chat-widget');
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/app/components/LatencyPill.css
+++ b/src/app/components/LatencyPill.css
@@ -4,7 +4,9 @@
   position: fixed;
   bottom: 16px;
   right: 16px;
-  z-index: 1200;
+  /* Above the chat-widget button (z-index 9998) when present; on pages
+     without it the pill simply sits in the bottom-right corner. */
+  z-index: 9999;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -52,11 +54,25 @@
   color: #ff6b6b;
 }
 
-/* Mobile: lift above the ContextPanel info button (bottom: 24px)
+/* When the ChatWidget is on the page, lift the pill above its 60×60
+   button so it isn't covered. ChatWidget toggles `has-chat-widget` on
+   <body> in componentDidMount/Unmount. */
+.has-chat-widget .LatencyPill {
+  bottom: 92px;
+  right: 24px;
+}
+
+/* Mobile: lift above the ContextPanel info button (bottom:24, 48×48)
    so they don't stack on the same pixel. */
 @media (max-width: 768px) {
   .LatencyPill {
     bottom: 80px;
     right: 16px;
+  }
+  /* On mobile the chat button sits higher (bottom:88, 60×60), so the
+     pill needs to clear that instead. */
+  .has-chat-widget .LatencyPill {
+    bottom: 156px;
+    right: 24px;
   }
 }


### PR DESCRIPTION
## Summary
- **Product Analytics — \"CTR by Product Property\"**: Aito's proposition-selection change broke `relate: {product: id}` (where `product` is a link). It now returns just two hits — an `\$and` over every linked product field, plus the trivial `{product: {\$has: id}}` — neither of which the UI knows how to render, so the panel went empty. Fetch the product first and pass its property bag as the relate value (`relate: {product: productProps}`) so Aito enumerates clean per-property propositions (`product.name`, `product.category`, `product.tags`, …) in the shape `ProductPage.js` already consumes. Verified live against `shared.aito.ai/db/aito-demo`: 10 unique hits, no duplicates.
- **LatencyPill hidden behind chat button**: the `ChatWidget` button (`bottom: 24/88px right: 24px`, `z-index: 9998`) covered the pill. Bumped pill `z-index` to 9999 and lifted its position only when the chat widget is on the page — `ChatWidget` toggles a `has-chat-widget` body class on mount/unmount (mirroring the existing `contextpanel-expanded` and `sidebar-collapsed` patterns), and the pill keeps its original lower position on every page that doesn't render the widget.

## Test plan
- [ ] `/product` page: \"CTR by Product Property\" panel populates for several products (banana, milk, etc.) with non-trivial lifts, no duplicate rows.
- [ ] Other Product Analytics panels (Customer Segment, Shopping Basket, Search Trends, Time-series) still render — the rest of the batch query is unchanged.
- [ ] Landing page: latency pill appears above the orange chat-widget button on both desktop (bottom-right corner) and mobile (bottom-right, two buttons stacked vertically below).
- [ ] Non-landing pages (e.g. `/product`, `/help`, `/admin`): latency pill sits in its original lower position (`bottom: 16px` desktop, `bottom: 80px` mobile above the ContextPanel info button).
- [ ] Navigate landing → other page → landing: body class is added/removed cleanly, pill repositions correctly each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)